### PR TITLE
Fix spotdl dependency to v3.6.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ oauthlib
 pydub
 requests
 requests_oauthlib
-spotdl
+spotdl==v3.6.0
 typer
 uvicorn
 youtube-dl


### PR DESCRIPTION
v3.6.1 removes the utils module and thereby breaks the code.